### PR TITLE
Potential fix for code scanning alert no. 13: Information exposure through an exception

### DIFF
--- a/backend/Routes/booking.py
+++ b/backend/Routes/booking.py
@@ -4,6 +4,7 @@ from models import House, PropertyBooking, db
 from schemas import PropertyBookingSchema
 from datetime import datetime, time
 from flask_mail import Mail, Message
+import logging
 
 booking_bp = Blueprint('booking' , __name__)
 
@@ -16,7 +17,8 @@ def get_bookings():
         results = PropertyBookingSchema.dump(all_bookings)
         return jsonify(results), 200
     except Exception as e:
-        return jsonify({"error": str(e), "status": "fail"}), 500
+        logging.exception("Error occurred in get_bookings.")
+        return jsonify({"error": "An internal error has occurred.", "status": "fail"}), 500
 
 @booking_bp.route('/addBooking', methods=['POST','OPTIONS'])
 def add_booking():
@@ -67,8 +69,8 @@ def add_booking():
 
     except Exception as e:
         db.session.rollback()  # Rollback the session on error
-        return jsonify({"error": str(e), "status": "fail"}), 500  # Handle exceptions
-
+        logging.exception("Error occurred in add_booking.")
+        return jsonify({"error": "An internal error has occurred.", "status": "fail"}), 500  # Handle exceptions
 
 
 @booking_bp.route('/getBookingDetails', methods=['GET'])
@@ -101,7 +103,8 @@ def get_booking_details():
         return jsonify(booking_details), 200
 
     except Exception as e:
-        return jsonify({"error": str(e), "status": "fail"}), 500
+        logging.exception("Error occurred in get_booking_details.")
+        return jsonify({"error": "An internal error has occurred.", "status": "fail"}), 500
 
 @booking_bp.route('/getBookingDetailsByUser/<int:user_id>', methods=['GET'])
 def get_booking_details_by_user(user_id):
@@ -133,7 +136,8 @@ def get_booking_details_by_user(user_id):
         return jsonify(booking_details), 200
 
     except Exception as e:
-        return jsonify({"error": str(e), "status": "fail"}), 500
+        logging.exception("Error occurred in get_booking_details_by_user.")
+        return jsonify({"error": "An internal error has occurred.", "status": "fail"}), 500
 
 
 @booking_bp.route('/confirmBooking/<int:booking_id>', methods=['POST'])


### PR DESCRIPTION
Potential fix for [https://github.com/RohanaHarsha/daffodilzone/security/code-scanning/13](https://github.com/RohanaHarsha/daffodilzone/security/code-scanning/13)

To fix the issue, the code should not return the raw string representation of the exception to the user in the error response. Instead, a generic error message such as "An internal error has occurred" should be used. The exception details (including optionally the stack trace) should be logged on the server side for developers to debug the application.  
This pattern should be applied consistently to all error handlers in the file (the same anti-pattern appears on lines 19, 70, 104, and 136 in the provided code).

To implement this fix:

- Replace every `return jsonify({"error": str(e), "status": "fail"})` with `return jsonify({"error": "An internal error has occurred.", "status": "fail"})`.
- Add server-side logging of the exception (with stack trace). The standard Python library `logging` should be used.
- Import the `logging` module near the top of the file.
- Optionally, configure basic logging if not already set up.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
